### PR TITLE
Enhance navigation and add commerce showcase section

### DIFF
--- a/src/components/CommerceShowcase.tsx
+++ b/src/components/CommerceShowcase.tsx
@@ -1,0 +1,53 @@
+const CommerceShowcase = () => {
+  const features = [
+    {
+      title: "All-in-one commerce tools",
+      text: "Manage products, payments, and marketing from a single dashboard—just like hosted platforms such as Shopify.",
+      icon: (
+        <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 3h18v4H3zM3 9h18v12H3z" />
+        </svg>
+      ),
+    },
+    {
+      title: "Open-source flexibility",
+      text: "Customize every part of your store with an open architecture inspired by frameworks like Spree Commerce.",
+      icon: (
+        <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14M12 5l7 7-7 7" />
+        </svg>
+      ),
+    },
+    {
+      title: "Built to scale",
+      text: "From first sale to global brand, our infrastructure grows with you.",
+      icon: (
+        <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 17l6-6 4 4 8-8" />
+        </svg>
+      ),
+    },
+  ];
+
+  return (
+    <section className="py-24 bg-orpeaks-section-bg">
+      <div className="container-orpeaks text-center">
+        <h2 className="text-3xl font-bold text-foreground mb-4">Built for modern commerce</h2>
+        <p className="text-muted-foreground mb-12 max-w-2xl mx-auto">
+          We combine the best of hosted platforms with the flexibility of open-source solutions so you can build the store you imagine.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+          {features.map((feature) => (
+            <div key={feature.title} className="p-8 bg-card/60 border border-border rounded-xl backdrop-blur-sm">
+              <div className="mb-4 text-primary flex justify-center">{feature.icon}</div>
+              <h3 className="text-xl font-semibold text-foreground mb-2">{feature.title}</h3>
+              <p className="text-muted-foreground leading-relaxed">{feature.text}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CommerceShowcase;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,14 +1,54 @@
 const Footer = () => {
   const currentYear = new Date().getFullYear();
 
+  const sections = [
+    {
+      title: "Product",
+      links: ["Features", "Pricing", "Integrations", "Templates"],
+    },
+    {
+      title: "Company",
+      links: ["About", "Careers", "Blog", "Contact"],
+    },
+    {
+      title: "Resources",
+      links: ["Docs", "Guides", "Community", "Support"],
+    },
+  ];
 
   return (
     <footer className="bg-orpeaks-section-bg border-t border-border">
       <div className="container-orpeaks py-16">
-        <div className="text-center">
-          <div className="text-2xl font-bold text-foreground mb-2">
-            ORPEAKS
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-12">
+          <div>
+            <div className="text-2xl font-bold text-foreground mb-4">
+              ORPEAKS
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Commerce platform for the MENA region.
+            </p>
           </div>
+          {sections.map((section) => (
+            <div key={section.title}>
+              <h4 className="font-semibold text-foreground mb-4">
+                {section.title}
+              </h4>
+              <ul className="space-y-2">
+                {section.links.map((link) => (
+                  <li key={link}>
+                    <a
+                      href="#"
+                      className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                    >
+                      {link}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="text-center">
           <p className="text-muted-foreground text-sm">
             © {currentYear} ORPEAKS. All rights reserved.
           </p>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,11 @@
 import ContactForm from './ContactForm';
 
 const Navigation = () => {
+  const navItems = [
+    { label: "Features", href: "#features" },
+    { label: "Pricing", href: "#pricing" },
+    { label: "Resources", href: "#resources" },
+  ];
 
   return (
     <nav className="sticky top-0 z-50 bg-background/80 backdrop-blur-sm border-b border-border">
@@ -14,8 +19,29 @@ const Navigation = () => {
           </div>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:block">
+          <div className="hidden md:flex items-center space-x-8">
+            {navItems.map((item) => (
+              <a
+                key={item.label}
+                href={item.href}
+                className="text-sm font-medium text-foreground hover:text-primary transition-colors"
+              >
+                {item.label}
+              </a>
+            ))}
             <ContactForm />
+            <a
+              href="#login"
+              className="text-sm font-medium text-foreground hover:text-primary transition-colors"
+            >
+              Log in
+            </a>
+            <a
+              href="#start"
+              className="btn-primary text-sm font-medium px-4 py-2"
+            >
+              Start free trial
+            </a>
           </div>
 
           {/* Mobile Navigation */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import Hero from "@/components/Hero";
 import WhyOrpeaks from "@/components/WhyOrpeaks";
 import LaunchStrip from "@/components/LaunchStrip";
 import FeatureTiles from "@/components/FeatureTiles";
+import CommerceShowcase from "@/components/CommerceShowcase";
 import SolutionHeader from "@/components/SolutionHeader";
 import DeepDives from "@/components/DeepDives";
 import MenaFocus from "@/components/MenaFocus";
@@ -41,6 +42,7 @@ const Index = () => {
         <WhyOrpeaks />
         <LaunchStrip />
         <FeatureTiles />
+        <CommerceShowcase />
         <SolutionHeader />
         <DeepDives />
         <MenaFocus />


### PR DESCRIPTION
## Summary
- expand navigation with feature, pricing, and resource links plus clear call-to-action
- build richer footer with product, company, and resource link groups
- introduce CommerceShowcase section showcasing platform flexibility and scalability

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npx eslint src/components/Navigation.tsx src/components/Footer.tsx src/components/CommerceShowcase.tsx src/pages/Index.tsx`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b03d935474832bacf039e6f5aebae8