### PR TITLE
Simplify navigation and add free trial modal

### DIFF
--- a/src/components/FeatureTiles.tsx
+++ b/src/components/FeatureTiles.tsx
@@ -1,69 +1,77 @@
+import {
+  LayoutDashboard,
+  MonitorCog,
+  Boxes,
+  Store,
+  ShoppingCart,
+  CreditCard,
+  RotateCcw,
+  Mail,
+  Link as LinkIcon,
+} from "lucide-react";
+
 const FeatureTiles = () => {
   const tiles = [
     {
-      title: "New Admin Dashboard Experience",
-      text: "A redesigned dashboard for faster, smarter day-to-day management. Your team will love it!",
-      icon: "dashboard"
+      title: "Admin Dashboard",
+      text: "Manage your operations with an intuitive, real-time dashboard.",
+      icon: LayoutDashboard,
     },
     {
-      title: "A No-code Customizable Storefront", 
-      text: "Mobile-first, built for content & conversion. Drag & drop sections – no developers needed.",
-      icon: "storefront"
+      title: "No-code Storefront Customization",
+      text: "Design your storefront with drag-and-drop simplicity—no coding required.",
+      icon: MonitorCog,
     },
     {
-      title: "Integrations with Stripe, Stripe Connect, and Klaviyo",
-      text: "No-code integrations to manage payments, marketing automations, and analytics at scale.",
-      icon: "integrations"
-    }
+      title: "Inventory Management",
+      text: "Track stock levels and organize products effortlessly across locations.",
+      icon: Boxes,
+    },
+    {
+      title: "Multi-Store Support",
+      text: "Run multiple storefronts from a single account with centralized control.",
+      icon: Store,
+    },
+    {
+      title: "Checkout System",
+      text: "Streamlined checkout optimized for conversions on any device.",
+      icon: ShoppingCart,
+    },
+    {
+      title: "Payment Integrations",
+      text: "Accept payments with ease through built-in gateways and providers.",
+      icon: CreditCard,
+    },
+    {
+      title: "Refunds and Order Management",
+      text: "Process returns and manage orders with clear, simple workflows.",
+      icon: RotateCcw,
+    },
+    {
+      title: "Email Marketing",
+      text: "Engage customers and automate campaigns with powerful email tools.",
+      icon: Mail,
+    },
+    {
+      title: "API Integrations",
+      text: "Connect your tech stack through flexible, well-documented APIs.",
+      icon: LinkIcon,
+    },
   ];
 
-  const getIcon = (iconType: string) => {
-    switch (iconType) {
-      case 'dashboard':
-        return (
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-          </svg>
-        );
-      case 'storefront':
-        return (
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
-          </svg>
-        );
-      case 'integrations':
-        return (
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v14a2 2 0 002 2z" />
-          </svg>
-        );
-      default:
-        return null;
-    }
-  };
-
   return (
-    <section className="py-24 bg-background">
+    <section id="features" className="py-24 bg-background">
       <div className="container-orpeaks">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
-          {tiles.map((tile, index) => (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
+          {tiles.map(({ title, text, icon: Icon }, index) => (
             <div key={index} className="text-center">
-              {/* Image placeholder with icon */}
               <div className="card-hover bg-card/60 border border-border rounded-xl p-8 mb-6 backdrop-blur-sm">
                 <div className="aspect-video bg-gradient-to-br from-primary/20 to-primary/5 rounded-lg flex items-center justify-center">
-                  <div className="text-primary">
-                    {getIcon(tile.icon)}
-                  </div>
+                  <Icon className="w-8 h-8 text-primary" />
                 </div>
               </div>
-              
-              {/* Content */}
-              <h3 className="text-xl font-semibold text-foreground mb-3">
-                {tile.title}
-              </h3>
-              <p className="text-muted-foreground leading-relaxed">
-                {tile.text}
-              </p>
+              <h3 className="text-xl font-semibold text-foreground mb-3">{title}</h3>
+              <p className="text-muted-foreground leading-relaxed">{text}</p>
             </div>
           ))}
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,58 +1,13 @@
 const Footer = () => {
   const currentYear = new Date().getFullYear();
 
-  const sections = [
-    {
-      title: "Product",
-      links: ["Features", "Pricing", "Integrations", "Templates"],
-    },
-    {
-      title: "Company",
-      links: ["About", "Careers", "Blog", "Contact"],
-    },
-    {
-      title: "Resources",
-      links: ["Docs", "Guides", "Community", "Support"],
-    },
-  ];
-
   return (
     <footer className="bg-orpeaks-section-bg border-t border-border">
-      <div className="container-orpeaks py-16">
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-12">
-          <div>
-            <div className="text-2xl font-bold text-foreground mb-4">
-              ORPEAKS
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Commerce platform for the MENA region.
-            </p>
-          </div>
-          {sections.map((section) => (
-            <div key={section.title}>
-              <h4 className="font-semibold text-foreground mb-4">
-                {section.title}
-              </h4>
-              <ul className="space-y-2">
-                {section.links.map((link) => (
-                  <li key={link}>
-                    <a
-                      href="#"
-                      className="text-sm text-muted-foreground hover:text-primary transition-colors"
-                    >
-                      {link}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-        <div className="text-center">
-          <p className="text-muted-foreground text-sm">
-            © {currentYear} ORPEAKS. All rights reserved.
-          </p>
-        </div>
+      <div className="container-orpeaks py-8 text-center space-y-2">
+        <div className="text-2xl font-bold text-foreground">ORPEAKS</div>
+        <p className="text-sm text-muted-foreground">
+          © {currentYear} ORPEAKS. All rights reserved.
+        </p>
       </div>
     </footer>
   );

--- a/src/components/FreeTrialModal.tsx
+++ b/src/components/FreeTrialModal.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+
+const FreeTrialModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    toast({
+      title: "Thanks for your interest!",
+      description: "We'll notify you as soon as we launch.",
+    });
+    setIsSubmitting(false);
+    setIsOpen(false);
+    (e.target as HTMLFormElement).reset();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <button className="btn-primary text-sm font-medium px-4 py-2">
+          Start Free Trial
+        </button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md bg-card border-border">
+        <DialogHeader>
+          <DialogTitle className="text-foreground">
+            We're opening soon!
+          </DialogTitle>
+          <DialogDescription className="text-muted-foreground">
+            Leave your contact info and we'll notify you when we launch.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="trial-name" className="text-foreground">
+              Name
+            </Label>
+            <Input
+              id="trial-name"
+              name="name"
+              required
+              className="bg-background border-border text-foreground"
+              placeholder="Your name"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="trial-email" className="text-foreground">
+              Email
+            </Label>
+            <Input
+              id="trial-email"
+              name="email"
+              type="email"
+              required
+              className="bg-background border-border text-foreground"
+              placeholder="you@example.com"
+            />
+          </div>
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
+          >
+            {isSubmitting ? "Submitting..." : "Notify Me"}
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FreeTrialModal;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,52 +1,23 @@
-import ContactForm from './ContactForm';
+import ContactForm from "./ContactForm";
+import FreeTrialModal from "./FreeTrialModal";
 
 const Navigation = () => {
-  const navItems = [
-    { label: "Features", href: "#features" },
-    { label: "Pricing", href: "#pricing" },
-    { label: "Resources", href: "#resources" },
-  ];
-
   return (
     <nav className="sticky top-0 z-50 bg-background/80 backdrop-blur-sm border-b border-border">
       <div className="container-orpeaks">
         <div className="flex items-center justify-between h-16">
-          {/* Logo */}
           <div className="flex-shrink-0">
             <a href="#" className="text-2xl font-bold text-foreground">
               ORPEAKS
             </a>
           </div>
-
-          {/* Desktop Navigation */}
           <div className="hidden md:flex items-center space-x-8">
-            {navItems.map((item) => (
-              <a
-                key={item.label}
-                href={item.href}
-                className="text-sm font-medium text-foreground hover:text-primary transition-colors"
-              >
-                {item.label}
-              </a>
-            ))}
             <ContactForm />
-            <a
-              href="#login"
-              className="text-sm font-medium text-foreground hover:text-primary transition-colors"
-            >
-              Log in
-            </a>
-            <a
-              href="#start"
-              className="btn-primary text-sm font-medium px-4 py-2"
-            >
-              Start free trial
-            </a>
+            <FreeTrialModal />
           </div>
-
-          {/* Mobile Navigation */}
-          <div className="md:hidden">
+          <div className="md:hidden flex items-center space-x-4">
             <ContactForm />
+            <FreeTrialModal />
           </div>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,18 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ORPEAKS Design System - Dark theme optimized for MENA eCommerce platform */
+/* ORPEAKS Design System - Light theme inspired by modern commerce platforms */
 
 @layer base {
   :root {
     /* ORPEAKS Brand Colors (HSL) */
-    --orpeaks-deep-pine: 166 75% 5%; /* #051C15 - Page background */
-    --orpeaks-section-bg: 166 76% 8%; /* #072720 - Section/Card background */
-    --orpeaks-border: 166 49% 15%; /* #133B32 - Borders */
-    --orpeaks-text-main: 0 0% 88%; /* #E0E0E0 - Main text */
-    --orpeaks-text-muted: 0 0% 63%; /* #A0A0A0 - Muted text */
-    --orpeaks-accent: 154 89% 58%; /* #36F4A4 - Accent Avocado */
-    --orpeaks-accent-hover: 154 75% 52%; /* #2AD98C - Accent hover */
+    --orpeaks-deep-pine: 0 0% 95%; /* #f3f3f3 - Page background */
+    --orpeaks-section-bg: 0 0% 100%; /* #ffffff - Section/Card background */
+    --orpeaks-border: 0 0% 85%; /* #d6d6d6 - Borders */
+    --orpeaks-text-main: 240 10% 3.9%; /* #0a0a0a - Main text */
+    --orpeaks-text-muted: 0 0% 40%; /* #666666 - Muted text */
+    --orpeaks-accent: 142 76% 36%; /* Brand green */
+    --orpeaks-accent-hover: 142 70% 31%; /* Darker brand green for hover */
 
     /* Semantic design tokens */
     --background: var(--orpeaks-deep-pine);
@@ -26,19 +26,19 @@
     --popover-foreground: var(--orpeaks-text-main);
 
     --primary: var(--orpeaks-accent);
-    --primary-foreground: var(--orpeaks-deep-pine);
+    --primary-foreground: var(--orpeaks-section-bg);
 
     --secondary: var(--orpeaks-section-bg);
     --secondary-foreground: var(--orpeaks-text-main);
 
-    --muted: var(--orpeaks-section-bg);
+    --muted: 0 0% 97%;
     --muted-foreground: var(--orpeaks-text-muted);
 
     --accent: var(--orpeaks-accent);
-    --accent-foreground: var(--orpeaks-deep-pine);
+    --accent-foreground: var(--orpeaks-section-bg);
 
     --destructive: 0 84% 60%;
-    --destructive-foreground: var(--orpeaks-text-main);
+    --destructive-foreground: var(--orpeaks-section-bg);
 
     --border: var(--orpeaks-border);
     --input: var(--orpeaks-border);
@@ -47,12 +47,12 @@
     --radius: 0.5rem;
 
     /* Custom gradients */
-    --hero-gradient: linear-gradient(135deg, hsl(var(--orpeaks-deep-pine)), hsl(166 67% 9%));
+    --hero-gradient: linear-gradient(135deg, hsl(var(--orpeaks-section-bg)), hsl(0 0% 98%));
     --card-gradient: linear-gradient(135deg, hsla(var(--orpeaks-section-bg), 0.6), hsla(var(--orpeaks-section-bg), 0.8));
-    
+
     /* Animation easing */
     --ease-orpeaks: cubic-bezier(0.16, 1, 0.3, 1);
-    
+
     /* MENA badge colors */
     --mena-ring: var(--orpeaks-accent);
     --mena-dots: var(--orpeaks-accent);


### PR DESCRIPTION
## Summary
- streamline navigation to only "Contact Us" and a new Start Free Trial modal
- replace footer with minimalist copyright block
- add responsive grid of nine feature cards with icons
- switch design tokens to light theme with green accents

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, no-require-imports)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68b046febc4c832b8ed9f400657ad373