### PR TITLE
style: enhance hero and feature sections

### DIFF
--- a/src/components/FeatureTiles.tsx
+++ b/src/components/FeatureTiles.tsx
@@ -1,71 +1,72 @@
+import { LayoutDashboard, PanelsTopLeft, Boxes, Store, ShoppingCart, CreditCard, Undo2, Mail, Plug } from "lucide-react";
+
+const features = [
+  {
+    title: "Admin Dashboard",
+    text: "Manage your operations with an intuitive, real-time dashboard.",
+    icon: LayoutDashboard,
+  },
+  {
+    title: "No-code Storefront Customization",
+    text: "Design your storefront with drag-and-drop simplicity—no coding required.",
+    icon: PanelsTopLeft,
+  },
+  {
+    title: "Inventory Management",
+    text: "Track stock levels and organize products effortlessly across locations.",
+    icon: Boxes,
+  },
+  {
+    title: "Multi-Store Support",
+    text: "Run multiple storefronts from a single account with centralized control.",
+    icon: Store,
+  },
+  {
+    title: "Checkout System",
+    text: "Streamlined checkout optimized for conversions on any device.",
+    icon: ShoppingCart,
+  },
+  {
+    title: "Payment Integrations",
+    text: "Accept payments with ease through built-in gateways and providers.",
+    icon: CreditCard,
+  },
+  {
+    title: "Refunds and Order Management",
+    text: "Process returns and manage orders with clear, simple workflows.",
+    icon: Undo2,
+  },
+  {
+    title: "Email Marketing",
+    text: "Engage customers and automate campaigns with powerful email tools.",
+    icon: Mail,
+  },
+  {
+    title: "API Integrations",
+    text: "Connect your tech stack through flexible, well-documented APIs.",
+    icon: Plug,
+  },
+];
+
 const FeatureTiles = () => {
-  const tiles = [
-    {
-      title: "New Admin Dashboard Experience",
-      text: "A redesigned dashboard for faster, smarter day-to-day management. Your team will love it!",
-      icon: "dashboard"
-    },
-    {
-      title: "A No-code Customizable Storefront", 
-      text: "Mobile-first, built for content & conversion. Drag & drop sections – no developers needed.",
-      icon: "storefront"
-    },
-    {
-      title: "Integrations with Stripe, Stripe Connect, and Klaviyo",
-      text: "No-code integrations to manage payments, marketing automations, and analytics at scale.",
-      icon: "integrations"
-    }
-  ];
-
-  const getIcon = (iconType: string) => {
-    switch (iconType) {
-      case 'dashboard':
-        return (
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-          </svg>
-        );
-      case 'storefront':
-        return (
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
-          </svg>
-        );
-      case 'integrations':
-        return (
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v14a2 2 0 002 2z" />
-          </svg>
-        );
-      default:
-        return null;
-    }
-  };
-
   return (
-    <section className="py-24 bg-background">
+    <section id="features" className="py-24 bg-background">
       <div className="container-orpeaks">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
-          {tiles.map((tile, index) => (
-            <div key={index} className="text-center">
-              {/* Image placeholder with icon */}
-              <div className="card-hover bg-card/60 border border-border rounded-xl p-8 mb-6 backdrop-blur-sm">
-                <div className="aspect-video bg-gradient-to-br from-primary/20 to-primary/5 rounded-lg flex items-center justify-center">
-                  <div className="text-primary">
-                    {getIcon(tile.icon)}
+          {features.map((feature, index) => {
+            const Icon = feature.icon;
+            return (
+              <div key={index} className="text-center">
+                <div className="card-hover bg-card/60 border border-border rounded-xl p-8 mb-6 backdrop-blur-sm">
+                  <div className="aspect-video bg-gradient-to-br from-primary/20 to-primary/5 rounded-lg flex items-center justify-center">
+                    <Icon className="w-8 h-8 text-primary" />
                   </div>
                 </div>
+                <h3 className="text-xl font-semibold text-foreground mb-3">{feature.title}</h3>
+                <p className="text-muted-foreground leading-relaxed">{feature.text}</p>
               </div>
-              
-              {/* Content */}
-              <h3 className="text-xl font-semibold text-foreground mb-3">
-                {tile.title}
-              </h3>
-              <p className="text-muted-foreground leading-relaxed">
-                {tile.text}
-              </p>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </section>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react';
+import { ArrowUpRight } from 'lucide-react';
 
 const Hero = () => {
   const wordsRef = useRef<HTMLDivElement>(null);
+  const partnerLogos = ["KFC", "GoDaddy", "Bonobos", "Bookshop", "Huckberry", "Paneco"];
 
   useEffect(() => {
     const words = wordsRef.current?.querySelectorAll('.hero-word');
@@ -43,27 +45,59 @@ const Hero = () => {
               <span className="hero-word inline-block">thing</span>
             </div>
           </h1>
-          
+
           {/* Supporting paragraph */}
           <p className="text-xl sm:text-2xl text-muted-foreground mb-12 max-w-2xl mx-auto leading-relaxed">
             ORPEAKS gives you everything you need to start and grow your online business in the MENA region.
           </p>
-          
+
           {/* CTAs */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <a 
-              href="#start" 
+            <a
+              href="#start"
               className="btn-primary inline-flex items-center justify-center min-w-[180px]"
             >
               Start for Free
             </a>
-            <a 
-              href="#features" 
+            <a
+              href="#features"
               className="btn-outline inline-flex items-center justify-center min-w-[180px]"
             >
               Explore Features
             </a>
           </div>
+
+          {/* Partner logos */}
+          <div className="mt-16">
+            <p className="text-sm text-muted-foreground mb-4">Trusted by leading brands</p>
+            <div className="marquee">
+              <div className="marquee-content">
+                {partnerLogos.concat(partnerLogos).map((logo, index) => (
+                  <div
+                    key={index}
+                    className="text-muted-foreground/70 font-semibold text-xl whitespace-nowrap mx-6"
+                  >
+                    {logo}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Release badge */}
+      <div className="absolute top-8 right-8 text-right">
+        <div className="bg-primary/10 border border-primary/20 rounded-lg px-4 py-3">
+          <p className="text-xs uppercase text-primary mb-1">ORPEAKS</p>
+          <p className="text-sm font-semibold leading-snug text-foreground">
+            The Biggest
+            <br />
+            Release Ever
+          </p>
+          <a href="#" className="mt-2 inline-block text-primary">
+            <ArrowUpRight className="w-4 h-4" />
+          </a>
         </div>
       </div>
       

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/index.css
+++ b/src/index.css
@@ -122,6 +122,22 @@
   .container-orpeaks {
     @apply max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8;
   }
+
+  /* Marquee animation for partner logos */
+  @keyframes marquee {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-50%); }
+  }
+
+  .marquee {
+    @apply overflow-hidden;
+  }
+
+  .marquee-content {
+    @apply flex items-center gap-12;
+    width: max-content;
+    animation: marquee 30s linear infinite;
+  }
   
   /* Reduced motion support */
   @media (prefers-reduced-motion: reduce) {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,10 @@
 import Navigation from "@/components/Navigation";
 import Hero from "@/components/Hero";
 import WhyOrpeaks from "@/components/WhyOrpeaks";
-import LaunchStrip from "@/components/LaunchStrip";
 import FeatureTiles from "@/components/FeatureTiles";
 import CommerceShowcase from "@/components/CommerceShowcase";
-import SolutionHeader from "@/components/SolutionHeader";
-import DeepDives from "@/components/DeepDives";
+import UseCaseGrid from "@/components/UseCaseGrid";
+import StoriesGrid from "@/components/StoriesGrid";
 import MenaFocus from "@/components/MenaFocus";
 import Testimonial from "@/components/Testimonial";
 import FinalCta from "@/components/FinalCta";
@@ -35,25 +34,24 @@ const Index = () => {
         }}
       />
       
-      <Navigation />
-      
-      <main>
-        <Hero />
-        <WhyOrpeaks />
-        <LaunchStrip />
-        <FeatureTiles />
-        <CommerceShowcase />
-        <SolutionHeader />
-        <DeepDives />
-        <MenaFocus />
-        <Testimonial />
-        <FinalCta />
-      </main>
-      
-      <Footer />
-      <Toaster />
-    </div>
-  );
-};
+        <Navigation />
+
+        <main>
+          <Hero />
+          <WhyOrpeaks />
+          <FeatureTiles />
+          <CommerceShowcase />
+          <UseCaseGrid />
+          <StoriesGrid />
+          <MenaFocus />
+          <Testimonial />
+          <FinalCta />
+        </main>
+
+        <Footer />
+        <Toaster />
+      </div>
+    );
+  };
 
 export default Index;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -95,5 +96,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add Spree-style release badge and partner logo marquee to hero
- expand features into icon-driven grid
- streamline index page layout and add marquee utility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b05be28258832b9980cb307be53448