### PR TITLE
fix: add missing React import on home page

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Navigation from "@/components/Navigation";
 import Hero from "@/components/Hero";
 import Features from "@/components/Features";


### PR DESCRIPTION
## Summary
- import React in home page to avoid runtime errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68b074ee5694832bae8c9b7b41dd6428