### PR TITLE
feat: redesign hero section

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,61 +1,65 @@
+import { useEffect, useState } from 'react';
+
+const phrases = [
+  'big thing',
+  'one to watch',
+  'category creator',
+  'unicorn startup',
+  'household name',
+  'global empire',
+  'solo flier',
+  'store they line up for',
+];
+
 const Hero = () => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIndex((prev) => (prev + 1) % phrases.length);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const phrase = phrases[index];
+
   return (
-    <section id="Hero" className="home-header-wrap alignfull text-align-left">
-      <div className="home-header">
-        <div className="container-flex">
-          <div className="desc-wrap">
-            <div className="desc">
-              <h1>Be the next big thing</h1>
-              <p>ORPEAKS gives you everything you need to start and grow your online business in the MENA region.</p>
-              <div className="buttons-wrap">
-                <a href="#start" className="btn blue large">Start for Free</a>
-                <a href="#features" className="btn white large">Explore Features</a>
-              </div>
-            </div>
-
-            <div className="visual">
-              <picture>
-                <source width="1848" height="2020" srcSet="https://spreecommerce.org/wp-content/themes/spree/images/home-visual.webp" media="(min-width: 1025px)" />
-                <source width="1000" height="1093" srcSet="https://spreecommerce.org/wp-content/themes/spree/images/home-visual-mobile.webp" media="(min-width: 768px) and (max-width: 1024px)" />
-                <img width="1" height="1" src="https://spreecommerce.org/wp-content/themes/spree/images/blank.webp" alt="" />
-              </picture>
-            </div>
-
-            <div className="header-logos-wrap" aria-label="Trusted by logos">
-              <div className="logos-swiper-wrap">
-                <div className="logos-marquee" role="presentation">
-                  <div className="track">
-                    <img width="108" height="40" src="/cdn.../kfc.svg" alt="KFC" />
-                    <img width="108" height="40" src="/cdn.../meundies.svg" alt="MeUndies" />
-                    <img width="108" height="40" src="/cdn.../mitchells.svg" alt="Mitchells" />
-                    <img width="108" height="40" src="/cdn.../on-cloud.svg" alt="On Cloud" />
-                    <img width="108" height="40" src="/cdn.../paneco.svg" alt="Paneco" />
-                    <img width="108" height="40" src="/cdn.../Square_LogoLockup_Black-1.svg" alt="Square" />
-                    <img width="108" height="40" src="/cdn.../stylemyle.svg" alt="Stylemyle" />
-                    <img width="108" height="40" src="/cdn.../bonobos.svg" alt="Bonobos" />
-                    <img width="108" height="40" src="/cdn.../bookshop.svg" alt="Bookshop" />
-                    <img width="108" height="40" src="/cdn.../godaddy.svg" alt="GoDaddy" />
-                    <img width="108" height="40" src="/cdn.../goop.svg" alt="Goop" />
-                    <img width="108" height="40" src="/cdn.../huckberry.svg" alt="Huckberry" />
-
-                    <img width="108" height="40" src="/cdn.../kfc.svg" alt="KFC" aria-hidden="true" />
-                    <img width="108" height="40" src="/cdn.../meundies.svg" alt="MeUndies" aria-hidden="true" />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <aside id="LaunchStrip" className="five-info" aria-label="Release highlight">
-            <p className="claim">Bigger, Better, More</p>
-            <p className="five">
-              <img width="120" height="120" src="https://spreecommerce.org/wp-content/themes/spree/images/five.webp" alt="" />
-            </p>
-            <p className="title">The Biggest<br/>Release Ever</p>
-            <a href="#" className="btn-icon lightblue2" aria-label="Read about the release">
-              <img width="24" height="24" src="https://spreecommerce.org/wp-content/themes/spree/images/arrow-right-top.svg" alt="" />
-            </a>
-          </aside>
+    <section
+      className="relative grid grid-cols-1 pb-0 text-foreground pt-40 bg-cover bg-center bg-no-repeat overflow-hidden"
+      style={{
+        backgroundImage:
+          "url('https://cdn.shopify.com/b/shopify-brochure2-assets/7ecd57f2fa3d7b997d29181a62c954ee.png?originalWidth=1920&originalHeight=1080')",
+      }}
+    >
+      <video
+        aria-label="Footage of merchants making sales, managing their business, and celebrating their success."
+        autoPlay
+        loop
+        muted
+        playsInline
+        className="absolute inset-0 w-full h-full object-cover"
+        src="https://cdn.shopify.com/shopifycloud/brochure/assets/home/hero-dark-b9aa9e3025eea3a701d59a04b1ed47ce6738c8b67cdd192d08bc7569b0ce3f4b.mp4"
+      />
+      <div className="container relative z-10 flex flex-col justify-end gap-6 sm:min-h-[60vh] lg:min-h-[80vh] pt-32 pb-20">
+        <h1 className="text-5xl sm:text-7xl font-bold leading-tight">
+          Be the next{' '}
+          <span key={phrase} className="block sm:inline hero-word animate-in">
+            {phrase}
+          </span>
+        </h1>
+        <p className="max-w-md sm:max-w-sm text-lg text-foreground/80">
+          Dream big, build fast, and grow far on ORPEAKS.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-4">
+          <a href="#start" className="btn-primary text-center w-full sm:w-auto">
+            Start for free
+          </a>
+          <button
+            type="button"
+            className="btn-outline w-full sm:w-auto"
+          >
+            Why we build ORPEAKS
+          </button>
         </div>
       </div>
     </section>
@@ -63,3 +67,4 @@ const Hero = () => {
 };
 
 export default Hero;
+


### PR DESCRIPTION
## Summary
- Revamp hero section with Tailwind layout, background video, and rotating taglines
- Replace buttons with design-system utilities for primary and outline styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b0abde906c832bb237976112ba9eb6