### PR TITLE
Revamp landing page and add launch signup modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,7 +31,7 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  background: hsl(var(--orpeaks-deep-pine));
+  background: hsl(var(--orpeaks-background));
 }
 
 ::-webkit-scrollbar-thumb {

--- a/src/components/DeepDives.tsx
+++ b/src/components/DeepDives.tsx
@@ -1,50 +1,36 @@
 const DeepDives = () => {
+  const baseUrl = "https://raw.githubusercontent.com/mousabamen/orpeaks-launchpad/refs/heads/main/imagea/";
   const features = [
     {
       title: "Storefront customization",
       text: "Easily customize your homepage, product listings and product detail pages. Use the default storefront or connect your own next.js frontend application.",
-      align: "left"
+      align: "left",
+      image: "storefront.avif",
     },
     {
-      title: "Multi-region & Multi-store", 
+      title: "Multi-region & Multi-store",
       text: "Manage unlimited products and variants individually or in bulk. Categorize, label, add custom attributes. Generate gift cards or discounts with a robust promo rule engine",
-      align: "right"
+      align: "right",
+      image: "multi-region.avif",
     },
     {
       title: "Inventory management",
       text: "Manage stock levels across sales channels and locations. Track stock movements, receive stock, make transfers. Make products available or discontinued on a given date.",
-      align: "left"
+      align: "left",
+      image: "inventory.avif",
     },
     {
       title: "Cart & Checkout",
       text: "Customize checkout to reflect your business logic. Style it to be on-brand. Manage shipping and taxes calculations. Enable fast checkout with Apple Pay or Google Pay.",
-      align: "right"
+      align: "right",
+      image: "cart-checkout.avif",
     },
     {
       title: "Payments & Refunds",
       text: "Capture payments with cards, Apple Pay, Google Pay, BNPL, local bank transfers and redirects, on terms. Use one or multiple payment processors. Automate refunds.",
-      align: "left"
+      align: "left",
+      image: "payments.avif",
     },
-    {
-      title: "Order & Return management",
-      text: "Manage orders via admin dashboard or rely on automated order processing. Use order splitting by vendor in a dropshipping model. Support partial or full returns and exchanges.",
-      align: "right"
-    },
-    {
-      title: "Order Fulfillment",
-      text: "Manage shipping across regions and warehouses. Use any shipping provider or aggregator. Track shippments in real time with email notifications for customers.",
-      align: "left"
-    },
-    {
-      title: "Emails & Marketing Automations",
-      text: "Customize on-brand email notifications for customers around any order-related events. Automate post-purchase upselling, eg. abandoned cart emails or other scenarios.",
-      align: "right"
-    },
-    {
-      title: "API & Integrations",
-      text: "Connect ORPEAKS to any custom user interface eg. a Next.js storefront or a mobile app. Integrate ORPEAKS with any system using APIs or webhooks, eg. WMS, ERP, CRM.",
-      align: "left"
-    }
   ];
 
   return (
@@ -58,30 +44,19 @@ const DeepDives = () => {
                 feature.align === 'right' ? 'lg:flex-row-reverse' : ''
               }`}
             >
-              {/* Image placeholder */}
               <div className="flex-1 lg:max-w-lg">
-                <div className="card-hover bg-card/60 border border-border rounded-xl p-8 backdrop-blur-sm">
-                  <div className="aspect-video bg-gradient-to-br from-primary/20 to-primary/5 rounded-lg flex items-center justify-center">
-                    <div className="text-center">
-                      <div className="w-12 h-12 bg-primary/20 rounded-lg flex items-center justify-center mb-3 mx-auto">
-                        <svg className="w-6 h-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                        </svg>
-                      </div>
-                      <p className="text-sm text-muted-foreground">{feature.title}</p>
-                    </div>
-                  </div>
+                <div className="card-hover bg-card border border-border rounded-xl p-6">
+                  <img
+                    src={`${baseUrl}${feature.image}`}
+                    alt=""
+                    className="w-full h-auto rounded-lg object-cover"
+                  />
                 </div>
               </div>
-              
-              {/* Content */}
+
               <div className="flex-1 lg:max-w-lg">
-                <h3 className="text-3xl font-bold text-foreground mb-6">
-                  {feature.title}
-                </h3>
-                <p className="text-lg text-muted-foreground leading-relaxed">
-                  {feature.text}
-                </p>
+                <h3 className="text-3xl font-bold text-foreground mb-6">{feature.title}</h3>
+                <p className="text-lg text-muted-foreground leading-relaxed">{feature.text}</p>
               </div>
             </div>
           ))}

--- a/src/components/FeatureTiles.tsx
+++ b/src/components/FeatureTiles.tsx
@@ -1,46 +1,22 @@
 const FeatureTiles = () => {
+  const baseUrl = "https://raw.githubusercontent.com/mousabamen/orpeaks-launchpad/refs/heads/main/imagea/";
   const tiles = [
     {
       title: "New Admin Dashboard Experience",
       text: "A redesigned dashboard for faster, smarter day-to-day management. Your team will love it!",
-      icon: "dashboard"
+      image: "admin-dashboard.avif",
     },
     {
-      title: "A No-code Customizable Storefront", 
+      title: "A No-code Customizable Storefront",
       text: "Mobile-first, built for content & conversion. Drag & drop sections – no developers needed.",
-      icon: "storefront"
+      image: "nocode-storefront.avif",
     },
     {
       title: "Integrations with Stripe, Stripe Connect, and Klaviyo",
       text: "No-code integrations to manage payments, marketing automations, and analytics at scale.",
-      icon: "integrations"
-    }
+      image: "api-integrations.avif",
+    },
   ];
-
-  const getIcon = (iconType: string) => {
-    switch (iconType) {
-      case 'dashboard':
-        return (
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-          </svg>
-        );
-      case 'storefront':
-        return (
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
-          </svg>
-        );
-      case 'integrations':
-        return (
-          <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v14a2 2 0 002 2z" />
-          </svg>
-        );
-      default:
-        return null;
-    }
-  };
 
   return (
     <section className="py-24 bg-background">
@@ -48,22 +24,15 @@ const FeatureTiles = () => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
           {tiles.map((tile, index) => (
             <div key={index} className="text-center">
-              {/* Image placeholder with icon */}
-              <div className="card-hover bg-card/60 border border-border rounded-xl p-8 mb-6 backdrop-blur-sm">
-                <div className="aspect-video bg-gradient-to-br from-primary/20 to-primary/5 rounded-lg flex items-center justify-center">
-                  <div className="text-primary">
-                    {getIcon(tile.icon)}
-                  </div>
-                </div>
+              <div className="card-hover bg-card border border-border rounded-xl p-6 mb-6">
+                <img
+                  src={`${baseUrl}${tile.image}`}
+                  alt=""
+                  className="w-full h-48 object-cover rounded-lg"
+                />
               </div>
-              
-              {/* Content */}
-              <h3 className="text-xl font-semibold text-foreground mb-3">
-                {tile.title}
-              </h3>
-              <p className="text-muted-foreground leading-relaxed">
-                {tile.text}
-              </p>
+              <h3 className="text-xl font-semibold text-foreground mb-3">{tile.title}</h3>
+              <p className="text-muted-foreground leading-relaxed">{tile.text}</p>
             </div>
           ))}
         </div>

--- a/src/components/FinalCta.tsx
+++ b/src/components/FinalCta.tsx
@@ -1,3 +1,5 @@
+import StartTrialModal from "./StartTrialModal";
+
 const FinalCta = () => {
   return (
     <section id="start" className="py-24 bg-orpeaks-section-bg/40">
@@ -9,9 +11,10 @@ const FinalCta = () => {
           <p className="text-xl text-muted-foreground mb-8 leading-relaxed">
             Join thousands of entrepreneurs who have chosen ORPEAKS to power their online stores.
           </p>
-          <a href="#" className="btn-primary inline-flex items-center justify-center text-lg px-8 py-4">
-            Get Started Today
-          </a>
+          <StartTrialModal
+            triggerText="Get Started Today"
+            className="btn-primary inline-flex items-center justify-center text-lg px-8 py-4"
+          />
         </div>
       </div>
     </section>

--- a/src/components/LaunchStrip.tsx
+++ b/src/components/LaunchStrip.tsx
@@ -1,0 +1,15 @@
+const LaunchStrip = () => {
+  return (
+    <section className="w-full bg-primary/10 border-y border-primary/20">
+      <div className="container-orpeaks flex items-center justify-center gap-4 py-2 text-sm">
+        <span className="px-2 py-1 rounded-full bg-primary text-primary-foreground text-xs font-semibold">New</span>
+        <span className="text-foreground">The Biggest Release Ever</span>
+        <a href="#" className="text-primary font-medium hover:underline">
+          Read more
+        </a>
+      </div>
+    </section>
+  );
+};
+
+export default LaunchStrip;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,31 +1,20 @@
-import ContactForm from './ContactForm';
+import StartTrialModal from "./StartTrialModal";
 
 const Navigation = () => {
-  const navItems = [
-    { label: "Features", href: "#features" },
-    { label: "Pricing", href: "#pricing" },
-    { label: "Resources", href: "#resources" },
-  ];
-
   return (
-    <header id="Navigation" className="site-header alignfull">
-      <div className="nav-inner">
-        <a className="brand" href="/">
+    <header id="Navigation" className="bg-white/80 backdrop-blur border-b border-border">
+      <div className="container-orpeaks flex items-center justify-between py-4">
+        <a href="/" className="text-xl font-bold text-foreground">
           ORPEAKS
         </a>
-        <nav className="primary-nav">
-          {navItems.map((item) => (
-            <a key={item.label} href={item.href}>
-              {item.label}
-            </a>
-          ))}
-        </nav>
-        <div className="nav-cta">
-          <ContactForm />
-          <a href="#login">Log in</a>
-          <a href="#start" className="btn blue">
-            Start free trial
+        <div className="flex items-center gap-6">
+          <a
+            href="mailto:contact@orpeaks.com"
+            className="text-sm font-medium text-foreground hover:text-primary transition-colors"
+          >
+            Contact Us
           </a>
+          <StartTrialModal className="btn-primary text-sm" />
         </div>
       </div>
     </header>

--- a/src/components/StartTrialModal.tsx
+++ b/src/components/StartTrialModal.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface StartTrialModalProps {
+  triggerText?: string;
+  className?: string;
+}
+
+const StartTrialModal = ({ triggerText = "Start Free Trial", className = "" }: StartTrialModalProps) => {
+  const [open, setOpen] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setOpen(false);
+    (e.target as HTMLFormElement).reset();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button className={className}>{triggerText}</button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md bg-card border-border">
+        <DialogHeader>
+          <DialogTitle className="text-center text-foreground">
+            We're opening soon! Leave your contact info and we’ll notify you when we launch.
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4 mt-4">
+          <div className="space-y-2">
+            <Label htmlFor="trial-name" className="text-foreground">Name</Label>
+            <Input id="trial-name" required className="bg-background border-border text-foreground" placeholder="Your name" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="trial-email" className="text-foreground">Email</Label>
+            <Input id="trial-email" type="email" required className="bg-background border-border text-foreground" placeholder="you@email.com" />
+          </div>
+          <Button type="submit" className="w-full bg-primary text-primary-foreground hover:bg-primary/90">Submit</Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default StartTrialModal;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/index.css
+++ b/src/index.css
@@ -7,16 +7,16 @@
 @layer base {
   :root {
     /* ORPEAKS Brand Colors (HSL) */
-    --orpeaks-deep-pine: 166 75% 5%; /* #051C15 - Page background */
-    --orpeaks-section-bg: 166 76% 8%; /* #072720 - Section/Card background */
-    --orpeaks-border: 166 49% 15%; /* #133B32 - Borders */
-    --orpeaks-text-main: 0 0% 88%; /* #E0E0E0 - Main text */
-    --orpeaks-text-muted: 0 0% 63%; /* #A0A0A0 - Muted text */
-    --orpeaks-accent: 154 89% 58%; /* #36F4A4 - Accent Avocado */
-    --orpeaks-accent-hover: 154 75% 52%; /* #2AD98C - Accent hover */
+    --orpeaks-background: 0 0% 95%; /* #f3f3f3 - Page background */
+    --orpeaks-section-bg: 0 0% 100%; /* #ffffff - Section/Card background */
+    --orpeaks-border: 0 0% 90%; /* #e5e5e5 - Borders */
+    --orpeaks-text-main: 0 0% 10%; /* #1a1a1a - Main text */
+    --orpeaks-text-muted: 0 0% 40%; /* #666666 - Muted text */
+    --orpeaks-accent: 154 89% 58%; /* Brand green */
+    --orpeaks-accent-hover: 154 75% 52%;
 
     /* Semantic design tokens */
-    --background: var(--orpeaks-deep-pine);
+    --background: var(--orpeaks-background);
     --foreground: var(--orpeaks-text-main);
 
     --card: var(--orpeaks-section-bg);
@@ -26,7 +26,7 @@
     --popover-foreground: var(--orpeaks-text-main);
 
     --primary: var(--orpeaks-accent);
-    --primary-foreground: var(--orpeaks-deep-pine);
+    --primary-foreground: 0 0% 100%;
 
     --secondary: var(--orpeaks-section-bg);
     --secondary-foreground: var(--orpeaks-text-main);
@@ -35,10 +35,10 @@
     --muted-foreground: var(--orpeaks-text-muted);
 
     --accent: var(--orpeaks-accent);
-    --accent-foreground: var(--orpeaks-deep-pine);
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84% 60%;
-    --destructive-foreground: var(--orpeaks-text-main);
+    --destructive-foreground: 0 0% 98%;
 
     --border: var(--orpeaks-border);
     --input: var(--orpeaks-border);
@@ -46,13 +46,9 @@
 
     --radius: 0.5rem;
 
-    /* Custom gradients */
-    --hero-gradient: linear-gradient(135deg, hsl(var(--orpeaks-deep-pine)), hsl(166 67% 9%));
-    --card-gradient: linear-gradient(135deg, hsla(var(--orpeaks-section-bg), 0.6), hsla(var(--orpeaks-section-bg), 0.8));
-    
     /* Animation easing */
     --ease-orpeaks: cubic-bezier(0.16, 1, 0.3, 1);
-    
+
     /* MENA badge colors */
     --mena-ring: var(--orpeaks-accent);
     --mena-dots: var(--orpeaks-accent);
@@ -93,15 +89,20 @@
   
   /* Button variants */
   .btn-primary {
-    @apply bg-primary text-primary-foreground font-semibold px-6 py-3 rounded-md transition-colors duration-200;
+    @apply bg-primary text-primary-foreground font-semibold px-6 py-3 rounded-md transition-colors duration-200 transform transition-transform;
   }
-  
+
   .btn-primary:hover {
     background-color: hsl(var(--orpeaks-accent-hover));
+    @apply scale-105;
   }
-  
+
   .btn-outline {
-    @apply border border-primary text-primary bg-transparent font-semibold px-6 py-3 rounded-md transition-all duration-200 hover:bg-primary/10;
+    @apply border border-primary text-primary bg-transparent font-semibold px-6 py-3 rounded-md transition-all duration-200 hover:bg-primary/10 transform transition-transform;
+  }
+
+  .btn-outline:hover {
+    @apply scale-105;
   }
   
   /* MENA badge */

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import Navigation from "@/components/Navigation";
 import Hero from "@/components/Hero";
 import WhyOrpeaks from "@/components/WhyOrpeaks";
+import LaunchStrip from "@/components/LaunchStrip";
 import FeatureTiles from "@/components/FeatureTiles";
 import CommerceShowcase from "@/components/CommerceShowcase";
 import SolutionHeader from "@/components/SolutionHeader";
@@ -15,7 +16,7 @@ const Index = () => {
   return (
     <div className="min-h-screen bg-background">
       {/* SEO Meta tags handled in index.html */}
-      
+
       {/* Structured Data */}
       <script
         type="application/ld+json"
@@ -33,12 +34,13 @@ const Index = () => {
           })
         }}
       />
-      
+
       <Navigation />
-      
+
       <main>
         <Hero />
         <WhyOrpeaks />
+        <LaunchStrip />
         <FeatureTiles />
         <CommerceShowcase />
         <SolutionHeader />
@@ -47,7 +49,7 @@ const Index = () => {
         <Testimonial />
         <FinalCta />
       </main>
-      
+
       <Footer />
       <Toaster />
     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -56,15 +57,15 @@ export default {
 					foreground: 'hsl(var(--card-foreground))'
 				},
 				// ORPEAKS brand colors
-				orpeaks: {
-					'deep-pine': 'hsl(var(--orpeaks-deep-pine))',
-					'section-bg': 'hsl(var(--orpeaks-section-bg))',
-					'border': 'hsl(var(--orpeaks-border))',
-					'text-main': 'hsl(var(--orpeaks-text-main))',
-					'text-muted': 'hsl(var(--orpeaks-text-muted))',
-					'accent': 'hsl(var(--orpeaks-accent))',
-					'accent-hover': 'hsl(var(--orpeaks-accent-hover))',
-				}
+                                orpeaks: {
+                                        background: 'hsl(var(--orpeaks-background))',
+                                        'section-bg': 'hsl(var(--orpeaks-section-bg))',
+                                        border: 'hsl(var(--orpeaks-border))',
+                                        'text-main': 'hsl(var(--orpeaks-text-main))',
+                                        'text-muted': 'hsl(var(--orpeaks-text-muted))',
+                                        accent: 'hsl(var(--orpeaks-accent))',
+                                        'accent-hover': 'hsl(var(--orpeaks-accent-hover))',
+                                }
 			},
 			borderRadius: {
 				lg: 'var(--radius)',
@@ -95,5 +96,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Switch site to light theme and refine button animations
- Simplify navigation and reuse a start-trial modal across the page
- Add launch strip and update feature sections with GitHub-hosted AVIF images

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68b0af1c0d78832ba0c78c3831089283